### PR TITLE
Featured content>Blog post redirects incorrectly on click

### DIFF
--- a/src/compatibility/shopify-objects/article.ts
+++ b/src/compatibility/shopify-objects/article.ts
@@ -50,9 +50,11 @@ export default function ShopifyArticle(
       blog,
       (blog) => blog.date_updated || blog.date_created,
     ),
-    url: deferWith([blog, blog.category], (blog, blogCategory) =>
-      blogCategory ? `/blogs/${blogCategory?.slug}/${blog.slug}` : '',
-    ),
+    url: deferWith([blog, blog.category], (blog, blogCategory) => {
+      const blogCategoryId =
+        blogCategory?.slug || blogCategory?.id || blog.category_id;
+      return blogCategoryId ? `/blogs/${blogCategoryId}/${blog.slug}` : '';
+    }),
     user: defer(() => blog.author),
 
     // Comments not supported


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1207329739803731/task/1211313827135482?focus=true

use category_id instead of slug if the block was created without BlogCategory