### PR TITLE
Locale at the cache key fixed

### DIFF
--- a/src/cache/html-cache/html-cache.ts
+++ b/src/cache/html-cache/html-cache.ts
@@ -383,7 +383,6 @@ export class HtmlCache {
 
   protected generateVersionHash(headers: Headers): string {
     const swellData = this.extractSwellData(headers);
-    const acceptLang = headers.get('accept-language') || '';
 
     const versionFactors = {
       store: headers.get('swell-storefront-id') || '',
@@ -395,8 +394,8 @@ export class HtmlCache {
       currency: (swellData['swell-currency'] as string) || 'USD',
       locale:
         headers.get('x-locale') ||
-        acceptLang.split(',')[0].trim().toLowerCase() ||
-        'default',
+        (swellData['swell-locale'] as string) ||
+        'en-US',
       context: headers.get('swell-storefront-context'),
       epoch: this.epoch,
     };


### PR DESCRIPTION
The cache key was incorrectly using the Accept-Language header, causing unnecessary cache fragmentation as this header varies between browsers/users. The locale subsystem actually reads from the swell-locale cookie (stored in swell-data), making Accept-Language irrelevant for locale determination.