### PR TITLE
filter out non-variant product options

### DIFF
--- a/src/compatibility/shopify-objects/line_item.ts
+++ b/src/compatibility/shopify-objects/line_item.ts
@@ -127,6 +127,9 @@ export default function ShopifyLineItem(
 
       return ShopifyVariant(instance, variant, item.product);
     }),
+    variant_id: deferWith([item.product, item.variant], (product, variant) => {
+      return variant?.id || product?.id;
+    }),
     vendor: undefined,
   });
 }

--- a/src/compatibility/shopify-objects/product.ts
+++ b/src/compatibility/shopify-objects/product.ts
@@ -385,6 +385,14 @@ function adjustProductVariants(
     return;
   }
 
+  const hasOptions =
+    Array.isArray(product.options) && product.options.length > 0;
+
+  if (hasOptions) {
+    // Shopify does not support non-variant options, so filter them out
+    product.options = product.options?.filter((option) => option.variant);
+  }
+
   const hasVariants =
     Array.isArray(product.variants?.results) &&
     product.variants.results.length > 0;


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1207329739803731/task/1211372833315013?focus=true

This update removes non-variant product options for Shopify (as Shopify only supports variant-based options) and adds the `variant_id` field to cart items