### PR TITLE
fall back without alt template if not found

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1356,8 +1356,8 @@ ${content.slice(pos)}`;
       );
     }
 
+    // Fall back to default template if alt not found
     if (!templateConfig) {
-      // Use sync helper internally
       templateConfig = this._getTemplateConfigByType('templates', name);
     }
 
@@ -1819,11 +1819,16 @@ ${content.slice(pos)}`;
     altTemplate?: string,
   ): Promise<ThemeSectionGroupInfo[]> {
     // Use sync helper internally
-    const pageConfig = this._getTemplateConfigByType(
+    let pageConfig = this._getTemplateConfigByType(
       'templates',
       pageId,
       altTemplate,
     );
+
+    // Fall back to default template if alt not found
+    if (!pageConfig) {
+      pageConfig = this._getTemplateConfigByType('templates', pageId);
+    }
 
     if (pageConfig === null) {
       return [];


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1207329739803731/task/1211144932170129?focus=true

- when rendering page sections, fall back to default template if alt template not found (same as when rendering full page)