### PR TITLE
fix: render tag to use cached versions of snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lodash-es": "^4.17.21",
         "qs": "^6.12.3",
         "strftime": "^0.10.3",
-        "swell-js": "^4.2.5"
+        "swell-js": "^5.1.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250902.0",
@@ -7803,9 +7803,10 @@
       }
     },
     "node_modules/swell-js": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/swell-js/-/swell-js-4.2.6.tgz",
-      "integrity": "sha512-5CqpGmXyhnJL0UVy2Kf/0xt88tFfD33iZdJlJMeGkBTeXNESuowF1FZgMfLeCxc8P5b8MqogHPrDNwirqs2unQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/swell-js/-/swell-js-5.1.2.tgz",
+      "integrity": "sha512-BXSMEpYEjFqjhrbob9P/f9e68zMft892/D9zZcWgSgnz9UWtGE4yKVwlXBnjs+bvuhuUfGcvIa7s1p8m4h51LQ==",
+      "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.3.1",
         "fast-case": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash-es": "^4.17.21",
     "qs": "^6.12.3",
     "strftime": "^0.10.3",
-    "swell-js": "^4.2.5"
+    "swell-js": "^5.1.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250902.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import { md5, toBase64, getKVFlavor } from './utils';
 import { logger, createTraceId, configureSdkLogger } from './utils/logger';
 import { isLikePromise } from './liquid/utils';
 
+import type { SwellClient } from 'swell-js';
 import type {
   SwellApiParams,
   SwellAppConfig,
@@ -42,7 +43,7 @@ export class Swell {
   public backend?: SwellBackendAPI;
 
   // Represends the Swell Storefront API
-  public storefront: typeof SwellJS;
+  public storefront: SwellClient<'snake'>;
 
   // Contains resources passed from server via request headers.
   public storefrontContext: SwellData;
@@ -214,7 +215,7 @@ export class Swell {
   ): Promise<T | undefined> {
     const cacheKey = getCacheKey(key, [this.instanceId, args]);
     const cache = this.getResourceCache();
-    
+
     // Use fetch for cache bypass, fetchSWR for normal operation
     if (this.shouldBypassCache()) {
       return cache.fetch<T>(cacheKey, handler, undefined, isCacheble);
@@ -434,7 +435,9 @@ export class Swell {
     return false;
   }
 
-  private getCacheableStorefrontRequestHandler<T>(storefront: typeof SwellJS) {
+  private getCacheableStorefrontRequestHandler<T>(
+    storefront: SwellClient<'snake'>,
+  ) {
     const storefrontRequest = storefront.request;
 
     return (method: string, url: string, id?: any, data?: any, opt?: any) => {
@@ -453,7 +456,7 @@ export class Swell {
           logger.debug('[SDK] Cacheable API request', { url: requestUrl, key });
           return storefrontRequest<T>(method, url, id, data, opt);
         };
-        
+
         // Use fetch for cache bypass, fetchSWR for normal operation
         if (this.shouldBypassCache()) {
           return cache.fetch<T>(key, fetchFn);

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -59,7 +59,7 @@ export class Cache {
   /**
    * Always fetches fresh data and updates cache
    * Deduplicates concurrent requests with the same key
-   * 
+   *
    * @param key Cache key
    * @param fetchFn Function to fetch fresh data
    * @param ttl Time to live in milliseconds (default: DEFAULT_SWR_TTL)
@@ -73,7 +73,7 @@ export class Cache {
   ): Promise<T> {
     // Check for concurrent request deduplication
     let promise = FETCH_PROMISE_MAP.get(key) as Promise<T> | undefined;
-    
+
     if (!promise) {
       promise = Promise.resolve()
         .then(fetchFn)
@@ -89,10 +89,10 @@ export class Cache {
         .finally(() => {
           FETCH_PROMISE_MAP.delete(key);
         });
-      
+
       FETCH_PROMISE_MAP.set(key, promise);
     }
-    
+
     return await promise;
   }
 
@@ -107,7 +107,7 @@ export class Cache {
     ttl: number = DEFAULT_SWR_TTL,
     isCacheble = true,
   ): Promise<T> {
-    const cacheValue = isCacheble ? await this.client.get(key) : undefined;
+    const cacheValue = isCacheble ? await this.client.get<T>(key) : undefined;
 
     // Do not create duplicate requests
     let promise = SWR_PROMISE_MAP.get(key);

--- a/src/compatibility/drops/collections.test.ts
+++ b/src/compatibility/drops/collections.test.ts
@@ -1,11 +1,10 @@
-import SwellJS from 'swell-js';
-
 import { describeFilter } from '../../liquid/test-helpers';
 
 import { ShopifyCompatibility } from '../shopify';
 
 import CollectionsDrop from './collections';
 
+import type { SwellClient } from 'swell-js';
 import type { SwellData } from 'types/swell';
 
 describeFilter('compatibility/drops/collections', (render, liquid) => {
@@ -40,7 +39,7 @@ describeFilter('compatibility/drops/collections', (render, liquid) => {
           }
         },
       } as unknown,
-    } as typeof SwellJS);
+    } as SwellClient);
   });
 
   it('should render collections drop', async () => {

--- a/src/compatibility/drops/pages.test.ts
+++ b/src/compatibility/drops/pages.test.ts
@@ -1,11 +1,10 @@
-import SwellJS from 'swell-js';
-
 import { describeFilter } from '../../liquid/test-helpers';
 
 import { ShopifyCompatibility } from '../shopify';
 
 import PagesDrop from './pages';
 
+import type { SwellClient } from 'swell-js';
 import type { SwellData } from 'types/swell';
 
 describeFilter('compatibility/drops/pages', (render, liquid) => {
@@ -54,7 +53,7 @@ describeFilter('compatibility/drops/pages', (render, liquid) => {
           }
         },
       } as unknown,
-    } as typeof SwellJS);
+    } as SwellClient);
   });
 
   it('should render pages drop', async () => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -30,6 +30,7 @@ import {
   getSectionLocation,
 } from './utils';
 
+import { unescapeLiquidSyntax } from './utils/escape';
 import { logger, createTraceId } from './utils/logger';
 
 import {
@@ -2262,14 +2263,6 @@ function parseJsonConfig<T>(config?: SwellThemeConfig | null): T {
     logger.warn(err);
     return {} as T;
   }
-}
-
-function replacerUnescape(match: string): string {
-  return match.includes('\\"') ? (JSON.parse(`"${match}"`) as string) : match;
-}
-
-function unescapeLiquidSyntax(template: string): string {
-  return template.replace(/\{\{.*?\}\}/g, replacerUnescape);
 }
 
 function extractSchemaTag(template: string): string {

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -1,0 +1,7 @@
+function replacerUnescape(match: string): string {
+  return match.includes('\\"') ? (JSON.parse(`"${match}"`) as string) : match;
+}
+
+export function unescapeLiquidSyntax(template: string): string {
+  return template.replace(/\{\{.*?\}\}/g, replacerUnescape);
+}


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1203548350351764/task/1210859415409038?focus=true

Added use of the built-in `liquidjs` cache mechanism for the `render` tag. This will allow `snippets` to render faster, since they will only be parsed once.

For the built-in `liquidjs` cache to work, it was necessary to extend the `liquid fs` implementation and implement the `exists` method.

Updated `swell-js` to `v5.1.2`. Also, the usage of types from swell-js has been updated.

Some files were formatted using eslint.
