### PR TITLE
Pricing not consistently reflected due to product cache

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -204,18 +204,17 @@ export class Swell {
   }
 
   /**
-   * Returns the cache key for this instance
-   * The key includes instance information (store-environment-deployment-theme-branch) and the current account_id
+   * Returns the currently logged account id
    * It is preferable to use the account_id from storefrontContext rather than the swell-session cookie, as the cookie contains a lot of other data
    * This increases the overall cache size
    */
-  private getInstanceCacheKey(): string {
+  private getAccountId(): string {
     const storefrontContext = this.storefrontContext as {
       account?: { id: string };
     };
     const accountId = storefrontContext?.account?.id || '';
 
-    return `${this.instanceId}:${accountId}`;
+    return accountId;
   }
 
   /**
@@ -228,7 +227,11 @@ export class Swell {
     handler: () => T | Promise<T>,
     isCacheble = true,
   ): Promise<T | undefined> {
-    const cacheKey = getCacheKey(key, [this.getInstanceCacheKey(), args]);
+    const cacheKey = getCacheKey(key, [
+      this.instanceId,
+      this.getAccountId(),
+      args,
+    ]);
     const cache = this.getResourceCache();
 
     // Use fetch for cache bypass, fetchSWR for normal operation
@@ -458,7 +461,8 @@ export class Swell {
     return (method: string, url: string, id?: any, data?: any, opt?: any) => {
       if (this.isStorefrontRequestCacheable(method, url, opt)) {
         const key = getCacheKey('request', [
-          this.getInstanceCacheKey(),
+          this.instanceId,
+          this.getAccountId(),
           method,
           url,
           id,
@@ -503,14 +507,13 @@ export class Swell {
    * Caches client resources in memory.
    */
   private getResourceCache(): Cache {
-    const instanceCacheKey = this.getInstanceCacheKey();
-    let cache = resourceCaches.get(instanceCacheKey);
+    let cache = resourceCaches.get(this.instanceId);
     if (cache === undefined) {
       cache = new ResourceCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      resourceCaches.set(instanceCacheKey, cache);
+      resourceCaches.set(this.instanceId, cache);
     }
     return cache;
   }
@@ -519,14 +522,13 @@ export class Swell {
    * Caches client storefront API requests in memory.
    */
   private getRequestCache(): Cache {
-    const instanceCacheKey = this.getInstanceCacheKey();
-    let cache = requestCaches.get(instanceCacheKey);
+    let cache = requestCaches.get(this.instanceId);
     if (cache === undefined) {
       cache = new RequestCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      requestCaches.set(instanceCacheKey, cache);
+      requestCaches.set(this.instanceId, cache);
     }
     return cache;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -204,6 +204,19 @@ export class Swell {
   }
 
   /**
+   * Returns a cache key for this instance
+   * Key includes instance information (store-environment-deployment-theme-branch) and current account_id
+   */
+  getCacheKey(): string {
+    const storefrontContext = this.storefrontContext as unknown as {
+      account?: { id: string };
+    };
+    const accountId = storefrontContext?.account?.id || '';
+
+    return `${this.instanceId}:${accountId}`;
+  }
+
+  /**
    * Fetches a resource.
    * First attempts to fetch from cache.
    */
@@ -213,7 +226,7 @@ export class Swell {
     handler: () => T | Promise<T>,
     isCacheble = true,
   ): Promise<T | undefined> {
-    const cacheKey = getCacheKey(key, [this.instanceId, args]);
+    const cacheKey = getCacheKey(key, [this.getCacheKey(), args]);
     const cache = this.getResourceCache();
 
     // Use fetch for cache bypass, fetchSWR for normal operation
@@ -443,7 +456,7 @@ export class Swell {
     return (method: string, url: string, id?: any, data?: any, opt?: any) => {
       if (this.isStorefrontRequestCacheable(method, url, opt)) {
         const key = getCacheKey('request', [
-          this.instanceId,
+          this.getCacheKey(),
           method,
           url,
           id,
@@ -488,13 +501,13 @@ export class Swell {
    * Caches client resources in memory.
    */
   private getResourceCache(): Cache {
-    let cache = resourceCaches.get(this.instanceId);
+    let cache = resourceCaches.get(this.getCacheKey());
     if (cache === undefined) {
       cache = new ResourceCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      resourceCaches.set(this.instanceId, cache);
+      resourceCaches.set(this.getCacheKey(), cache);
     }
     return cache;
   }
@@ -503,13 +516,13 @@ export class Swell {
    * Caches client storefront API requests in memory.
    */
   private getRequestCache(): Cache {
-    let cache = requestCaches.get(this.instanceId);
+    let cache = requestCaches.get(this.getCacheKey());
     if (cache === undefined) {
       cache = new RequestCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      requestCaches.set(this.instanceId, cache);
+      requestCaches.set(this.getCacheKey(), cache);
     }
     return cache;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -207,9 +207,10 @@ export class Swell {
    * Returns the cache key for this instance
    * The key includes instance information (store-environment-deployment-theme-branch) and the current account_id
    * It is preferable to use the account_id from storefrontContext rather than the swell-session cookie, as the cookie contains a lot of other data
+   * This increases the overall cache size
    */
-  getCacheKey(): string {
-    const storefrontContext = this.storefrontContext as unknown as {
+  private getInstanceCacheKey(): string {
+    const storefrontContext = this.storefrontContext as {
       account?: { id: string };
     };
     const accountId = storefrontContext?.account?.id || '';
@@ -227,7 +228,7 @@ export class Swell {
     handler: () => T | Promise<T>,
     isCacheble = true,
   ): Promise<T | undefined> {
-    const cacheKey = getCacheKey(key, [this.getCacheKey(), args]);
+    const cacheKey = getCacheKey(key, [this.getInstanceCacheKey(), args]);
     const cache = this.getResourceCache();
 
     // Use fetch for cache bypass, fetchSWR for normal operation
@@ -457,7 +458,7 @@ export class Swell {
     return (method: string, url: string, id?: any, data?: any, opt?: any) => {
       if (this.isStorefrontRequestCacheable(method, url, opt)) {
         const key = getCacheKey('request', [
-          this.getCacheKey(),
+          this.getInstanceCacheKey(),
           method,
           url,
           id,
@@ -502,13 +503,14 @@ export class Swell {
    * Caches client resources in memory.
    */
   private getResourceCache(): Cache {
-    let cache = resourceCaches.get(this.getCacheKey());
+    const instanceCacheKey = this.getInstanceCacheKey();
+    let cache = resourceCaches.get(instanceCacheKey);
     if (cache === undefined) {
       cache = new ResourceCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      resourceCaches.set(this.getCacheKey(), cache);
+      resourceCaches.set(instanceCacheKey, cache);
     }
     return cache;
   }
@@ -517,13 +519,14 @@ export class Swell {
    * Caches client storefront API requests in memory.
    */
   private getRequestCache(): Cache {
-    let cache = requestCaches.get(this.getCacheKey());
+    const instanceCacheKey = this.getInstanceCacheKey();
+    let cache = requestCaches.get(instanceCacheKey);
     if (cache === undefined) {
       cache = new RequestCache({
         kvStore: this.workerEnv?.THEME,
         workerCtx: this.workerCtx,
       });
-      requestCaches.set(this.getCacheKey(), cache);
+      requestCaches.set(instanceCacheKey, cache);
     }
     return cache;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -204,17 +204,18 @@ export class Swell {
   }
 
   /**
-   * Returns the currently logged account id
+   * Returns fields from the current account that may affect requests.
+   * Currently, only the 'group' field is returned.
    * It is preferable to use the account_id from storefrontContext rather than the swell-session cookie, as the cookie contains a lot of other data
    * This increases the overall cache size
    */
-  private getAccountId(): string {
+  private getAccountCacheKey(): string {
     const storefrontContext = this.storefrontContext as {
-      account?: { id: string };
+      account?: { group: string };
     };
-    const accountId = storefrontContext?.account?.id || '';
+    const group = storefrontContext?.account?.group || '';
 
-    return accountId;
+    return `${group}`;
   }
 
   /**
@@ -229,7 +230,7 @@ export class Swell {
   ): Promise<T | undefined> {
     const cacheKey = getCacheKey(key, [
       this.instanceId,
-      this.getAccountId(),
+      this.getAccountCacheKey(),
       args,
     ]);
     const cache = this.getResourceCache();
@@ -462,7 +463,7 @@ export class Swell {
       if (this.isStorefrontRequestCacheable(method, url, opt)) {
         const key = getCacheKey('request', [
           this.instanceId,
-          this.getAccountId(),
+          this.getAccountCacheKey(),
           method,
           url,
           id,

--- a/src/api.ts
+++ b/src/api.ts
@@ -204,8 +204,9 @@ export class Swell {
   }
 
   /**
-   * Returns a cache key for this instance
-   * Key includes instance information (store-environment-deployment-theme-branch) and current account_id
+   * Returns the cache key for this instance
+   * The key includes instance information (store-environment-deployment-theme-branch) and the current account_id
+   * It is preferable to use the account_id from storefrontContext rather than the swell-session cookie, as the cookie contains a lot of other data
    */
   getCacheKey(): string {
     const storefrontContext = this.storefrontContext as unknown as {


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1204122196581246/task/1213439244550830?focus=true

We use caching based on the current version of the storefront. Therefore, regardless of whether the user is logged in or not, the previously cached version of the product is loaded. However, the product price may depend on the current account (price can depend on account group). If we use the cached version, the product price will not change after logging in to an account with a different account group.

I added the current account_id to the cache keys. This way, if an account changes, its own cached version will be used. I don't clear the cache because it can be shared, as noted in the comments. I prefer the account_id from the storefrontContext instead of the swell-session cookie because we encode a lot of different data in the swell-session.

Note: this approach will increase the cache size.