### PR TITLE
fix: guard against missing store.url in ShopifyShop domain mapping

### DIFF
--- a/src/compatibility/shopify-objects/shop.ts
+++ b/src/compatibility/shopify-objects/shop.ts
@@ -27,7 +27,7 @@ export default function ShopifyShop(
     customer_accounts_enabled: true, // TODO: consider if we should provide a standard option
     customer_accounts_optional: true, // TODO
     description: store.description as string, // TODO
-    domain: store.url.replace(/^http[s]?:\/\//, '') as string,
+    domain: (store.url || `https://${store.id}.swell.store`).replace(/^http[s]?:\/\//, '') as string,
     email: store.support_email as string,
     enabled_currencies: store.currencies.map((currency: any) => ({
       // currency object


### PR DESCRIPTION
`ShopifyShop()` maps `domain` by calling `store.url.replace(...)` directly, which throws if a store has no `url` set (for example, no custom domain configured). This change falls back to `` https://${store.id}.swell.store `` when `url` is absent — the same default address `permanent_domain` already computes a few lines below — so the mapping degrades gracefully instead of crashing. No behavior change for stores with `url` set.
