### PR TITLE
fix: guard against undefined pageSection in renderSection

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1544,7 +1544,7 @@ ${content.slice(pos)}`;
           pageData,
         );
 
-        return pageSection.output || '';
+        return pageSection?.output ?? '';
       }
 
       return sectionContent;


### PR DESCRIPTION
`renderSection` returns `pageSection.output || ''`, but `pageSection` itself can be `undefined` when `renderPageSections` yields no result (for example, a reference to a deleted or misconfigured section), which throws and takes down the whole page render. Switching to `pageSection?.output ?? ''` degrades to an empty string instead. No change when `pageSection` resolves normally.
