### PR TITLE
Get config name from file_name

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -299,7 +299,8 @@ export class SwellTheme {
       presets: [],
       ...Array.from(settingConfigs.values()).reduce(
         (acc, config) => {
-          const configName = String(config?.name || '').split('.')[0];
+          const fileName = config?.file_path?.split('/').pop() || '';
+          const configName = fileName.split('.')[0];
           if (configName && config?.file_data) {
             let configValue: unknown;
             try {


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1204122196581246/task/1216960393089793?focus=true

We made changes to correctly identify the user model based on the file path and replace underscores (`_`) in the name with hyphens (`-`). 
However, the theme uses configuration files with "_" (e.g., `schema_settings.json`), and following these changes, we need to identify them correctly. To obtain the configuration name, I am using `file_name` instead of `name`.